### PR TITLE
Refactor : ChatRoomEntity 수정

### DIFF
--- a/src/main/java/com/github/supercodingfinalprojectbackend/entity/ChatRoom.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/entity/ChatRoom.java
@@ -4,6 +4,7 @@ import lombok.*;
 
 import javax.persistence.*;
 import java.sql.Timestamp;
+import org.hibernate.annotations.CreationTimestamp;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -12,7 +13,7 @@ import java.sql.Timestamp;
 @Builder
 @Entity
 @Table(name = "chat_rooms")
-public class ChatRoom extends CommonEntity {
+public class ChatRoom {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY) @Column(name = "chat_room_id",nullable = false)
     private Long chatRoomId;
@@ -23,11 +24,8 @@ public class ChatRoom extends CommonEntity {
     @Column(name = "is_chat")
     private Boolean isChat;
 
+    @CreationTimestamp
     @Column(name = "created_at")
     private Timestamp createdAt;
-
-
-
-
 
 }


### PR DESCRIPTION

## 📖 설명 📖
채팅방의 경우에는 BaseEntity에 있는 수정시간 및 삭제 여부를 제외한 생성시간만을 받아오고 싶어서 BaseEntity 상속을 없앴습니다.

<br>

## 🔧 추가 및 수정 🔧️

-상속받던 BaseEntity를 제거 하고 생성시간만 받고싶어서 createdAt 컬럼을 추가했습니다

<br>

## ✨ 이건 꼭 봐주세요! ✨
- BaseEntity를 삭제했습니다 삭제한 이유가 타당한지 한 번씩 봐주시면 감사하겠습니다!

```java
public class ChatRoom extends CommonEntity {
public class ChatRoom { 
```