### PR TITLE
Feat: 연관관계 매핑, id 참조타입 변경, id 변수명 변경

### DIFF
--- a/src/main/java/com/github/supercodingfinalprojectbackend/entity/ChatRoom.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/entity/ChatRoom.java
@@ -1,11 +1,13 @@
 package com.github.supercodingfinalprojectbackend.entity;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.*;
 import java.sql.Timestamp;
-import org.hibernate.annotations.CreationTimestamp;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -26,6 +28,5 @@ public class ChatRoom {
 
     @CreationTimestamp
     @Column(name = "created_at")
-    @CreationTimestamp
     private Timestamp createdAt;
 }

--- a/src/main/java/com/github/supercodingfinalprojectbackend/entity/CommonEntity.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/entity/CommonEntity.java
@@ -12,7 +12,7 @@ import java.time.Instant;
 @MappedSuperclass
 public abstract class CommonEntity {
     @Column(name = "is_deleted", nullable = false, columnDefinition = "tinyint default 0")
-    private boolean isDeleted;
+    private Boolean isDeleted;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/src/main/java/com/github/supercodingfinalprojectbackend/entity/Mentee.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/entity/Mentee.java
@@ -15,7 +15,7 @@ public class Mentee extends CommonEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "mentee_id")
-    private int id;
+    private Long menteeId;
 
     @OneToOne
     @JoinColumn(name = "account_id")

--- a/src/main/java/com/github/supercodingfinalprojectbackend/entity/MenteeAbstractAccount.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/entity/MenteeAbstractAccount.java
@@ -15,9 +15,9 @@ public class MenteeAbstractAccount extends CommonEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "mentee_abstract_account_id")
-    private int id;
+    private Long menteeAccountId;
     @Column(name = "account_number")
     private String accountNumber;
     @Column(name = "paymoney")
-    private long paymoney;
+    private Long paymoney;
 }

--- a/src/main/java/com/github/supercodingfinalprojectbackend/entity/MenteeSocialInfo.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/entity/MenteeSocialInfo.java
@@ -15,11 +15,15 @@ public class MenteeSocialInfo extends CommonEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "mentee_social_info_id")
-    private int id;
-    @Column(name = "mentee_id")
-    private int menteeId;
+    private Long menteeSocialId;
+
+    @ManyToOne
+    @JoinColumn(name = "mentee_id")
+    private Mentee mentee;
+
     @Column(name = "social_id")
-    private long socialId;
+    private Long socialId;
+
     @Column(name = "social_platform")
     private String socialPlatform;
 }

--- a/src/main/java/com/github/supercodingfinalprojectbackend/entity/OrderSheet.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/entity/OrderSheet.java
@@ -15,7 +15,7 @@ public class OrderSheet extends CommonEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "order_sheet_id")
-    private int id;
+    private Long orderSheetId;
     @ManyToOne
     @JoinColumn(name = "mentee_id")
     private Mentee mentee;
@@ -26,9 +26,9 @@ public class OrderSheet extends CommonEntity {
     @JoinColumn(name = "post_id")
     private Post post;
     @Column(name = "total_price")
-    private int totlaPrice;
+    private Integer totlaPrice;
     @Column(name = "is_completed")
-    private boolean isCompleted;
+    private Boolean isCompleted;
     @Column(name = "transaction_type")
     private String transactionType;
 }

--- a/src/main/java/com/github/supercodingfinalprojectbackend/entity/Posts.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/entity/Posts.java
@@ -17,8 +17,7 @@ public class Posts extends CommonEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_id", nullable = false)
-    private Integer postId;
-
+    private Long postId;
     @Column(name = "title")
     private String title;
     @Column(name = "level")
@@ -27,6 +26,10 @@ public class Posts extends CommonEntity{
     private String reviewObjective;
     @Column(name = "price")
     private Integer price;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mentor_id")
+    private Mentor mentor;
 
 
 }

--- a/src/main/java/com/github/supercodingfinalprojectbackend/entity/PostsContent.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/entity/PostsContent.java
@@ -14,11 +14,15 @@ public class PostsContent extends CommonEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "post_content_id", nullable = false)
-    private Integer postContentId;
+    private Long postContentId;
 
     @Column(name = "text")
     private String text;
 
     @Column(name = "location")
     private String location;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Posts posts;
 }

--- a/src/main/java/com/github/supercodingfinalprojectbackend/entity/PostsSkillStack.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/entity/PostsSkillStack.java
@@ -14,7 +14,7 @@ public class PostsSkillStack extends CommonEntity{
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "stack_id", nullable = false)
-    private Integer stackId;
+    private Long stackId;
 
     @Column(name = "post_stack")
     private String postStack;

--- a/src/main/java/com/github/supercodingfinalprojectbackend/entity/SelectedClassTime.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/entity/SelectedClassTime.java
@@ -15,7 +15,20 @@ public class SelectedClassTime extends CommonEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "selected_class_time_id")
-    private int id;
+    private Long selectedId;
+
+    @Column(name = "year")
+    private Integer year;
+
+    @Column(name = "month")
+    private Integer month;
+
+    @Column(name = "day")
+    private Integer day;
+
+    @Column(name = "hour")
+    private Integer hour;
+
     @ManyToOne
     @JoinColumn(name = "mentor_id")
     private Mentor mentor;


### PR DESCRIPTION

## 📖 설명 📖

- Posts, Posts_Content, Order_Sheet, selected_class_times, Mentees, Mentee_Social_Infos, Mentee_Abstract_Accounts Entity 연관관계 매핑

<br>

## 🔧 추가 및 수정 🔧️

- selected_class_times Entity에서 년,월,일,시 컬럼 추가
- Column의 Type을  기존 참조타입에서 원시타입으로 변경(int -> Integer)
- Entity의 Id 변수명 수정(id -> menteeAccountId)

<br>

## ✨ 이건 꼭 봐주세요! ✨

- Entity Id 변수명을 기존 id에서 보다 직관적으로 일부 수정하였습니다.(id -> menteeAccountId)
- 확인하신후 보다 좋은 이름으로 변경하셔도 좋을것 같습니다.
