### PR TITLE
주원님 드디어 원하시는 공통 응답 객체가 완성되었습니다!

### DIFF
--- a/src/main/java/com/github/supercodingfinalprojectbackend/controller/TestController.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/controller/TestController.java
@@ -1,9 +1,10 @@
 package com.github.supercodingfinalprojectbackend.controller;
 
-import com.github.supercodingfinalprojectbackend.dto.response.ApiResponse;
+import com.github.supercodingfinalprojectbackend.dto.response.PageResponse;
+import com.github.supercodingfinalprojectbackend.dto.response.JsonResponse;
+import com.github.supercodingfinalprojectbackend.exception.errorcode.ApiErrorCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,8 +16,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class TestController {
     @GetMapping("/")
     @Operation(summary = "스웨거 정상 동작 테스트")
-    public ResponseEntity<ApiResponse<String>> test() {
+    public JsonResponse<PageResponse<String>> test() {
 
-        return ApiResponse.success("this is data").toResponseEntity();
+        return JsonResponse.<PageResponse<String>>builder()
+                .status(203)
+                .message("hello, world")
+                .data(new PageResponse<String>())
+                .build();
     }
 }

--- a/src/main/java/com/github/supercodingfinalprojectbackend/controller/UserController.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.github.supercodingfinalprojectbackend.controller;
 
 import com.github.supercodingfinalprojectbackend.dto.response.ApiResponse;
+import com.github.supercodingfinalprojectbackend.dto.response.JsonResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,7 +19,7 @@ public class UserController {
     private final RestTemplate restTemplate = new RestTemplate();
 
     @GetMapping("/login")
-    public ApiResponse<String> login () {
+    public JsonResponse<String> login () {
         System.out.println("요청 처리함!");
         System.out.println(clientId);
 
@@ -26,6 +27,10 @@ public class UserController {
 //        ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
 //        System.out.println(response.getBody());
 
-        return ApiResponse.success("데이터", "요청 성공적으로 처리됨");
+        return JsonResponse.<String>builder()
+                .status(200)
+                .message("이거슨 메세지여")
+                .data("이거시 데이터여")
+                .build();
     }
 }

--- a/src/main/java/com/github/supercodingfinalprojectbackend/dto/response/ApiResponse.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/dto/response/ApiResponse.java
@@ -2,14 +2,13 @@ package com.github.supercodingfinalprojectbackend.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import org.springframework.http.ResponseEntity;
 
 @Getter
 @AllArgsConstructor
 @Schema(title = "공통응답 폼")
+@Deprecated(since = "v1.0.0")
 public class ApiResponse<T> {
     @Schema(title = "요청 성공 여부")
     private boolean success;

--- a/src/main/java/com/github/supercodingfinalprojectbackend/dto/response/JsonResponse.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/dto/response/JsonResponse.java
@@ -1,0 +1,30 @@
+package com.github.supercodingfinalprojectbackend.dto.response;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
+
+public class JsonResponse<T> extends ResponseEntity<JsonResponse.JsonForm<T>> {
+    public JsonResponse(JsonForm<T> body, MultiValueMap<String, String> headers, HttpStatus status) { super(body, headers, status); }
+    public JsonResponse(JsonForm<T> body, MultiValueMap<String, String> headers, Integer status) { super(body, headers, status); }
+    public static <T> JsonResponseBuilder<T> builder() { return new JsonResponseBuilder<>(); }
+
+    public static class JsonForm<T> {
+        private Boolean success;
+        private Integer status;
+        private String message;
+        private T data;
+
+        public JsonForm(Integer status, String message, T data) {
+            this.success = status >= 200 && status < 300;
+            this.status = status;
+            this.message = message;
+            this.data = data;
+        }
+
+        public Boolean getSuccess() { return success; }
+        public Integer getStatus() { return status; }
+        public String getMessage() { return message; }
+        public T getData() { return data; }
+    }
+}

--- a/src/main/java/com/github/supercodingfinalprojectbackend/dto/response/JsonResponseBuilder.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/dto/response/JsonResponseBuilder.java
@@ -1,0 +1,101 @@
+package com.github.supercodingfinalprojectbackend.dto.response;
+
+import org.springframework.http.*;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.function.Consumer;
+
+public class JsonResponseBuilder<T> {
+    private Integer status;
+    private String message;
+    private HttpHeaders headers = new HttpHeaders();
+    private T data;
+    public JsonResponseBuilder() {
+        this.status = 500;
+        this.message = "";
+    }
+    public JsonResponseBuilder<T> status(Integer status) {
+        this.status = status;
+        return this;
+    }
+    public JsonResponseBuilder<T> status(HttpStatus status) {
+        this.status = status.value();
+        return this;
+    }
+    public JsonResponseBuilder<T> message(String message) {
+        this.message = message;
+        return this;
+    }
+    public JsonResponseBuilder<T> data(T data) {
+        this.data = data;
+        return this;
+    }
+    public JsonResponseBuilder<T> header(String headerName, String... headerValues) {
+        for (String headerValue : headerValues) {
+            this.headers.add(headerName, headerValue);
+        }
+        return this;
+    }
+    public JsonResponseBuilder<T> headers(HttpHeaders headers) {
+        this.headers = headers;
+        return this;
+    }
+    public JsonResponseBuilder<T> headers(Consumer<HttpHeaders> headersConsumer) {
+        headersConsumer.accept(this.headers);
+        return this;
+    }
+    public JsonResponseBuilder<T> allow(HttpMethod... allowedMethods) {
+        this.headers.setAllow(new LinkedHashSet<>(Arrays.asList(allowedMethods)));
+        return this;
+    }
+    public JsonResponseBuilder<T> contentLength(long contentLength) {
+        this.headers.setContentLength(contentLength);
+        return this;
+    }
+    public JsonResponseBuilder<T> contentType(MediaType contentType) {
+        this.headers.setContentType(contentType);
+        return this;
+    }
+    public JsonResponseBuilder<T> eTag(String etag) {
+        if (!etag.startsWith("\"") && !etag.startsWith("W/\"")) {
+            etag = "\"" + etag;
+        }
+        if (!etag.endsWith("\"")) {
+            etag = etag + "\"";
+        }
+        this.headers.setETag(etag);
+        return this;
+    }
+    public JsonResponseBuilder<T> lastModified(ZonedDateTime date) {
+        this.headers.setLastModified(date);
+        return this;
+    }
+    public JsonResponseBuilder<T> lastModified(Instant date) {
+        this.headers.setLastModified(date);
+        return this;
+    }
+    public JsonResponseBuilder<T> lastModified(long date) {
+        this.headers.setLastModified(date);
+        return this;
+    }
+    public JsonResponseBuilder<T> location(URI location) {
+        this.headers.setLocation(location);
+        return this;
+    }
+    public JsonResponseBuilder<T> cacheControl(CacheControl cacheControl) {
+        this.headers.setCacheControl(cacheControl);
+        return this;
+    }
+    public JsonResponseBuilder<T> varyBy(String... requestHeaders) {
+        this.headers.setVary(Arrays.asList(requestHeaders));
+        return this;
+    }
+    public JsonResponse<T> build() {
+        JsonResponse.JsonForm<T> body = new JsonResponse.JsonForm<>(status, message, data);
+        return new JsonResponse<>(body, headers, status);
+    }
+}

--- a/src/main/java/com/github/supercodingfinalprojectbackend/exception/FilterExceptionHandler.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/exception/FilterExceptionHandler.java
@@ -1,7 +1,7 @@
 package com.github.supercodingfinalprojectbackend.exception;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.supercodingfinalprojectbackend.dto.response.ApiResponse;
+import com.github.supercodingfinalprojectbackend.dto.response.JsonResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -26,7 +25,7 @@ public class FilterExceptionHandler extends OncePerRequestFilter {
             log.info("Api 응답! {}", HttpStatus.valueOf(response.getStatus()));
         }
         catch (ApiException e) {
-            ApiResponse<?> data = ApiResponse.fail(e.getStatus(), e.getMessage());
+            JsonResponse.JsonForm<?> data = new JsonResponse.JsonForm<>(e.getStatus(), e.getMessage(), null);
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setStatus(e.getStatus());
             response.getOutputStream().write(new ObjectMapper()
@@ -34,7 +33,7 @@ public class FilterExceptionHandler extends OncePerRequestFilter {
             log.info("Api 응답! {}", HttpStatus.valueOf(response.getStatus()));
         }
         catch (Exception e) {
-            ApiResponse<?> data = ApiResponse.fail(500, e.getMessage());
+            JsonResponse.JsonForm<?> data = new JsonResponse.JsonForm<>(500, e.getMessage(), null);
             response.setContentType(MediaType.APPLICATION_JSON_VALUE);
             response.setStatus(500);
             response.getOutputStream().write(new ObjectMapper()

--- a/src/main/java/com/github/supercodingfinalprojectbackend/exception/ServletExceptionHandler.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/exception/ServletExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.github.supercodingfinalprojectbackend.exception;
 
 import com.github.supercodingfinalprojectbackend.dto.response.ApiResponse;
+import com.github.supercodingfinalprojectbackend.dto.response.JsonResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -8,8 +9,10 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class ServletExceptionHandler {
     @ExceptionHandler(ApiException.class)
-    public ResponseEntity<ApiResponse<?>> handleApiException(ApiException e) {
-        ApiResponse<?> data = ApiResponse.fail(e.getStatus(), e.getMessage());
-        return ResponseEntity.status(e.getStatus()).body(data);
+    public JsonResponse<?> handleApiException(ApiException e) {
+        return JsonResponse.builder()
+                .status(e.getStatus())
+                .message(e.getMessage())
+                .build();
     }
 }


### PR DESCRIPTION
## 📖 설명 📖

- JsonResponse가 구현되었고, 이에 따른 코드 변경이 있었습니다.

<br>

## 🔧 추가 및 수정 🔧️

- JsonResponse 추가
- ApiResponse은 deprecated 설정
- ApiResponse가 사용되던 코드를 JsonResponse로 변경

<br>

## ✨ 이건 꼭 봐주세요! ✨

- JsonResponse는 기존 ApiResponse의 기능에 더해 상태 코드가 헤더에도 자동 반영이 되고, 빌더를 통해 헤더를 커스텀할 수 있습니다.
- JsonResponse의 객체를 생성할 때는 빌더패턴으로 생성하게 됩니다.
- 단순 공통응답 폼만 필요한 경우 JsonResponse의 내부 클래스인 JsonForm을 사용할 수 있습니다.
- JsonForm은 빌더패턴이 들어 있지 않고 생성자 달랑 하나만 있어서 사용하기 불편할 수 있지만 아마 JsonForm을 직접 사용할 일이 거의 없을 것으로 생각됩니다.
