### PR TITLE
Refactor : Mentor List 조회 API  수정

### DIFF
--- a/src/main/java/com/github/supercodingfinalprojectbackend/controller/MentorController.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/controller/MentorController.java
@@ -24,23 +24,15 @@ public class MentorController {
 	private final MentorService mentorService;
 
 	@GetMapping
-
 	public ResponseEntity<ApiResponse<Page<MentorInfoResponse>>> getMentors(
-			@RequestParam(required = false, defaultValue = "") String keyWord,
+			@RequestParam(required = false, defaultValue = "") String keyword,
 			@RequestParam(required = false) List<String> skillStack,
 			@RequestParam(defaultValue = "0") Long cursor,
 			@RequestParam(defaultValue = "10") Integer pageSize
 	){
-//			return ResponseUtils.ok(
-//					"Mentor 리스트를 성공적으로 가져왔습니다.",
-//					mentorService.getMentors(keyWord, skillStack).stream()
-//							.map(MentorDto.MentorInfoResponse::from)
-//							.collect(Collectors.toList())
-//			);
-
 			return ResponseUtils.ok(
 					"Mentor 리스트를 성공적으로 가져왔습니다.",
-					mentorService.getMentors(keyWord, skillStack, cursor, PageRequest.of(0, pageSize))
+					mentorService.getMentors(keyword, skillStack, cursor, PageRequest.of(0, pageSize))
 			);
 	}
 }

--- a/src/main/java/com/github/supercodingfinalprojectbackend/dto/MentorDto.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/dto/MentorDto.java
@@ -27,9 +27,6 @@ public class MentorDto {
 	public static MentorDto fromEntity(Mentor mentor){
 		return MentorDto.builder()
 				.mentorId(mentor.getMentorId())
-//				Test 때 mentor 계좌가 없이 테스트 하느라 임시 주석
-//				.mentorAbstractAccountId(
-//						mentor.getMentorAbstractAccount().getMentorAbstractAccountId())
 				.name(mentor.getUser().getName())
 				.nickname(mentor.getUser().getNickname())
 				.introduction(mentor.getIntroduction())
@@ -41,30 +38,34 @@ public class MentorDto {
 
 	@Getter
 	@NoArgsConstructor
-	@AllArgsConstructor
 	@Builder
 	public static class MentorInfoResponse {
 
 		private Long mentorId;
-		private String name;
 		private String nickname;
-		private String email;
 		private String thumbnailImageUrl;
 		private String introduction;
 		private String company;
+		private String currentDuty;
+		private String currentPeriod;
 
 		@QueryProjection
-		public MentorInfoResponse(Long mentorId, String name, String introduction, String company){
+		public MentorInfoResponse(
+				Long mentorId, String nickname, String introduction, String company,
+				String currentDuty, String currentPeriod, String thumbnailImageUrl
+		) {
 			this.mentorId = mentorId;
-			this.name = name;
+			this.nickname = nickname;
 			this.introduction = introduction;
 			this.company = company;
+			this.currentDuty = currentDuty;
+			this.currentPeriod = currentPeriod;
+			this.thumbnailImageUrl = thumbnailImageUrl;
 		}
 
 		public static MentorInfoResponse from(MentorDto mentorDto){
 			return MentorInfoResponse.builder()
 					.mentorId(mentorDto.getMentorId())
-					.name(mentorDto.getName())
 					.introduction(mentorDto.getIntroduction())
 					.company(mentorDto.getCompany())
 					.thumbnailImageUrl(mentorDto.getThumbnailImageUrl())

--- a/src/main/java/com/github/supercodingfinalprojectbackend/entity/Mentor.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/entity/Mentor.java
@@ -38,6 +38,12 @@ public class Mentor extends CommonEntity {
 	@Column(name = "searchable")
 	private Boolean searchable;
 
+	@Column(name = "current_duty")
+	private String currentDuty;
+
+	@Column(name = "current_period")
+	private String currentPeriod;
+
 	public static Mentor from(User user, String company, String introduction) {
 		return Mentor.builder()
 				.mentorSkillStacks(null)

--- a/src/main/java/com/github/supercodingfinalprojectbackend/entity/MentorCareer.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/entity/MentorCareer.java
@@ -28,5 +28,5 @@ public class MentorCareer {
 	private String duty;
 
 	@Column(name = "period")
-	private Integer period;
+	private String period;
 }

--- a/src/main/java/com/github/supercodingfinalprojectbackend/repository/MentorRepositoryImpl.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/repository/MentorRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.github.supercodingfinalprojectbackend.repository;
 import static com.github.supercodingfinalprojectbackend.entity.QMentor.mentor;
 import static com.github.supercodingfinalprojectbackend.entity.QMentorSkillStack.mentorSkillStack;
 import static com.github.supercodingfinalprojectbackend.entity.QSkillStack.skillStack;
+import static com.github.supercodingfinalprojectbackend.entity.QUser.user;
 
 import com.github.supercodingfinalprojectbackend.dto.MentorDto.MentorInfoResponse;
 import com.github.supercodingfinalprojectbackend.dto.QMentorDto_MentorInfoResponse;
@@ -43,9 +44,12 @@ public class MentorRepositoryImpl implements MentorRepositoryCustom {
 		return jpaQueryFactory
 				.selectDistinct(new QMentorDto_MentorInfoResponse(
 						mentor.mentorId,
-						mentor.user.name,
+						mentor.user.nickname,
 						mentor.introduction,
-						mentor.company
+						mentor.company,
+						mentor.currentDuty,
+						mentor.currentPeriod,
+						mentor.user.thumbnailImageUrl
 				))
 				.from(mentor)
 				.leftJoin(mentor.mentorSkillStacks, mentorSkillStack)
@@ -64,9 +68,12 @@ public class MentorRepositoryImpl implements MentorRepositoryCustom {
 		List<MentorInfoResponse> content = jpaQueryFactory
 				.selectDistinct(new QMentorDto_MentorInfoResponse(
 						mentor.mentorId,
-						mentor.user.name,
+						mentor.user.nickname,
 						mentor.introduction,
-						mentor.company
+						mentor.company,
+						mentor.currentDuty,
+						mentor.currentPeriod,
+						mentor.user.thumbnailImageUrl
 				))
 				.from(mentor)
 				.leftJoin(mentor.mentorSkillStacks, mentorSkillStack)
@@ -93,15 +100,21 @@ public class MentorRepositoryImpl implements MentorRepositoryCustom {
 		List<MentorInfoResponse> content = jpaQueryFactory
 				.selectDistinct(new QMentorDto_MentorInfoResponse(
 						mentor.mentorId,
-						mentor.user.name,
+						mentor.user.nickname,
 						mentor.introduction,
-						mentor.company
+						mentor.company,
+						mentor.currentDuty,
+						mentor.currentPeriod,
+						mentor.user.thumbnailImageUrl
 				))
 				.from(mentor)
 				.leftJoin(mentor.mentorSkillStacks, mentorSkillStack)
 				.leftJoin(mentorSkillStack.skillStack, skillStack)
+				.leftJoin(mentor.user, user)
 				.where(
 						getRecordsWithCursorId(cursorId),
+						mentor.searchable.eq(true),
+						mentor.isDeleted.eq(false),
 						mentorNameLike(keyword).or(conMentorSkillStack(keyword)),
 						skillStackFiltering(skillStacks)
 				)
@@ -113,8 +126,11 @@ public class MentorRepositoryImpl implements MentorRepositoryCustom {
 				.from(mentor)
 				.leftJoin(mentor.mentorSkillStacks, mentorSkillStack)
 				.leftJoin(mentorSkillStack.skillStack, skillStack)
+				.leftJoin(mentor.user, user)
 				.where(
 						getRecordsWithCursorId(cursorId),
+						mentor.searchable.eq(true),
+						mentor.isDeleted.eq(false),
 						mentorNameLike(keyword).or(conMentorSkillStack(keyword)),
 						skillStackFiltering(skillStacks)
 				);
@@ -127,7 +143,7 @@ public class MentorRepositoryImpl implements MentorRepositoryCustom {
 	}
 
 	private BooleanExpression mentorNameLike(String keyword){
-		return keyword != null ? mentor.user.name.like("%" + keyword + "%") : null;
+		return keyword != null ? user.nickname.like("%" + keyword + "%") : null;
 	}
 
 	private BooleanExpression skillStackFiltering(List<String> skillStackList){
@@ -137,5 +153,4 @@ public class MentorRepositoryImpl implements MentorRepositoryCustom {
 	private BooleanExpression getRecordsWithCursorId(Long cursorId){
 		return cursorId != null ? mentor.mentorId.gt(cursorId) : null;
 	}
-
 }


### PR DESCRIPTION
DTO 수정, 검색 가능, 삭제된 유저, WHERE절 추가

## 🔧 추가 및 수정 🔧️

- MentorInfoResponse DTO 변경
   - currentDuty, currentPeriod 맴버 변수가 추가 됐습니다. (현재 근무지에 대한 직무와 경력을 반환하기 위해)
- 검색 가능, 삭제된 유저인지를 확인하여 Data를 반환할 수 있게 WHERE 절을 추가하였습니다.
```java
.where(
   getRecordsWithCursorId(cursorId),
   mentor.searchable.eq(true),
   mentor.isDeleted.eq(false),
   mentorNameLike(keyword).or(conMentorSkillStack(keyword)),
   skillStackFiltering(skillStacks)
)
```
- Name  -> Nickname으로 대체 되었습니다. 따라서 queryDsl 코드가 변경 됐습니다.
```java
private BooleanExpression mentorNameLike(String keyword){
	return keyword != null ? user.nickname.like("%" + keyword + "%") : null;
}
```


<br>

## ✨ 이건 꼭 봐주세요! ✨

- mentor Detail 조회 API를 개발할 예정입니다.
