### PR TITLE
Feat : mentor detail 정보를 가져오는 API 구현

### DIFF
--- a/src/main/java/com/github/supercodingfinalprojectbackend/controller/MentorController.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/controller/MentorController.java
@@ -1,8 +1,8 @@
 package com.github.supercodingfinalprojectbackend.controller;
 
+import com.github.supercodingfinalprojectbackend.dto.MentorDto;
 import com.github.supercodingfinalprojectbackend.dto.MentorDto.MentorInfoResponse;
 import com.github.supercodingfinalprojectbackend.service.MentorService;
-import java.util.List;
 import com.github.supercodingfinalprojectbackend.util.ResponseUtils;
 import com.github.supercodingfinalprojectbackend.util.ResponseUtils.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -10,10 +10,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -33,6 +32,17 @@ public class MentorController {
 			return ResponseUtils.ok(
 					"Mentor 리스트를 성공적으로 가져왔습니다.",
 					mentorService.getMentors(keyword, skillStack, cursor, PageRequest.of(0, pageSize))
+			);
+	}
+
+	@GetMapping("/detail/{mentorId}")
+	public ResponseEntity<ApiResponse<MentorDto.MentorDetailResponse>> getMentorDetail(
+			@PathVariable("mentorId") Long mentorId
+	){
+			return ResponseUtils.ok(
+					"Mentor 상세정보를 성공적으로 가져왔습니다.",
+					MentorDto.MentorDetailResponse.from(
+							mentorService.getMentorDetail(mentorId))
 			);
 	}
 }

--- a/src/main/java/com/github/supercodingfinalprojectbackend/dto/MentorCareerDto.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/dto/MentorCareerDto.java
@@ -1,5 +1,6 @@
 package com.github.supercodingfinalprojectbackend.dto;
 
+import com.github.supercodingfinalprojectbackend.entity.MentorCareer;
 import com.github.supercodingfinalprojectbackend.entity.type.DutyType;
 import lombok.*;
 
@@ -30,6 +31,13 @@ public class MentorCareerDto {
         return MentorCareerDto.builder()
                 .dutyType(DutyType.valueOf(request.dutyName.toUpperCase()).resolve())
                 .period(request.period)
+                .build();
+    }
+
+    public static MentorCareerDto from(MentorCareer mentorCareer) {
+        return MentorCareerDto.builder()
+                .dutyType(DutyType.valueOf(mentorCareer.getDuty()))
+                .period(mentorCareer.getPeriod())
                 .build();
     }
 

--- a/src/main/java/com/github/supercodingfinalprojectbackend/dto/MentorDto.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/dto/MentorDto.java
@@ -7,6 +7,7 @@ import com.github.supercodingfinalprojectbackend.util.ValidateUtils;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.*;
 
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -29,6 +30,8 @@ public class MentorDto {
 	private String currentPeriod;
 	private Set<MentorCareerDto> careerDtoSet;
 	private Set<SkillStackType> skillStackTypeSet;
+	private List<MentorCareerDto> mentorCareerList;
+
 
 	public static MentorDto from(Mentor mentor){
 		return MentorDto.builder()
@@ -41,6 +44,18 @@ public class MentorDto {
 				.company(mentor.getCompany())
 				.currentDuty(DutyType.valueOf(mentor.getCurrentDuty()).resolve())
 				.currentPeriod(mentor.getCurrentPeriod())
+				.build();
+	}
+
+	public static MentorDto from2(Mentor mentor){
+		return MentorDto.builder()
+				.mentorId(mentor.getMentorId())
+				.nickname(mentor.getUser().getNickname())
+				.thumbnailImageUrl(mentor.getUser().getThumbnailImageUrl())
+				.introduction(mentor.getIntroduction())
+				.company(mentor.getCompany())
+				.mentorCareerList(mentor.getMentorCareerList().stream()
+						.map(MentorCareerDto::from).collect(Collectors.toList()))
 				.build();
 	}
 
@@ -118,5 +133,30 @@ public class MentorDto {
 		public static JoinResponse from(MentorDto mentorDto) {
 			return new JoinResponse(mentorDto.getMentorId());
 		}
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class MentorDetailResponse {
+		private Long mentorId;
+		private String nickname;
+		private String introduction;
+		private String company;
+		private String thumbnailImageUrl;
+		private List<MentorCareerDto> mentorCareerList;
+
+		public static MentorDetailResponse from(MentorDto mentorDto) {
+			return MentorDetailResponse.builder()
+					.mentorId(mentorDto.getMentorId())
+					.nickname(mentorDto.getNickname())
+					.introduction(mentorDto.getIntroduction())
+					.company(mentorDto.getCompany())
+					.thumbnailImageUrl(mentorDto.getThumbnailImageUrl())
+					.mentorCareerList(mentorDto.getMentorCareerList())
+					.build();
+		}
+
 	}
 }

--- a/src/main/java/com/github/supercodingfinalprojectbackend/entity/Mentor.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/entity/Mentor.java
@@ -45,6 +45,9 @@ public class Mentor extends CommonEntity {
 	@Column(name = "current_period")
 	private String currentPeriod;
 
+	@OneToMany(mappedBy = "mentor")
+	private List<MentorCareer> mentorCareerList = new ArrayList<>();
+
 	public static Mentor from(User user, MentorDto mentorDto) {
 		return Mentor.builder()
 				.mentorSkillStacks(null)
@@ -58,4 +61,9 @@ public class Mentor extends CommonEntity {
 	}
 
 	public void setMentorSkillStacks(List<MentorSkillStack> mentorSkillStacks) { this.mentorSkillStacks = mentorSkillStacks; }
+
+	@Override
+	public boolean isValid() {
+		return !this.getIsDeleted() && this.getSearchable();
+	}
 }

--- a/src/main/java/com/github/supercodingfinalprojectbackend/service/MentorService.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/service/MentorService.java
@@ -2,13 +2,18 @@ package com.github.supercodingfinalprojectbackend.service;
 
 import com.github.supercodingfinalprojectbackend.dto.MentorDto;
 import com.github.supercodingfinalprojectbackend.dto.MentorDto.MentorInfoResponse;
+import com.github.supercodingfinalprojectbackend.entity.Mentor;
+import com.github.supercodingfinalprojectbackend.exception.ApiException;
 import com.github.supercodingfinalprojectbackend.repository.MentorRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.github.supercodingfinalprojectbackend.exception.errorcode.ApiErrorCode.NOT_FOUND_MENTOR;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -36,5 +41,15 @@ public class MentorService {
 //		1차 응답
 //		return mentors.stream().map(MentorDto::fromEntity).collect(Collectors.toList());
 		return mentors;
+	}
+
+	public MentorDto getMentorDetail(Long mentorId) {
+		Mentor mentor = mentorRepository.findById(mentorId)
+				.orElseThrow(() -> new ApiException(NOT_FOUND_MENTOR));
+
+		if (!mentor.isValid()) {
+			throw new ApiException(NOT_FOUND_MENTOR);
+		}
+		return MentorDto.from2(mentor);
 	}
 }


### PR DESCRIPTION
## 📖 설명 📖

- 멘토 id를 통해 멘토의 상세정보를 반환하는 API를 구현하였습니다. (멘토 리스트 페이지에서 사용 됩니다.)

<br>

## 🔧 추가 및 수정 🔧️

- Mentor Entity : MentorCareer를 쉽게 가져오기 위해 해당 필드를 추가하였습니다.
```java
@OneToMany(mappedBy = "mentor")
private List<MentorCareer> mentorCareerList = new ArrayList<>();
```
 - MentorDto
    - MentorDetailResponse 추가 : API 요청을 반환하기 위해서 내부 클래스를 추가하였습니다.
    - from2 메소드 추가 :  Service -> Controller로 보낼 때 Mentor Entity를 Dto로 변환하는 메소드를 추가하였습니다.
       - 기존 from 메소드가 존재하는데, Mentor에서 가져오는 정보가 다른 것 같아 from2 메소드를 새로 만들었습니다. 
       - 추후 기존 메소드와 가져오는 정보가 같아진다면, 하나로 통일하고, 그렇지 않다면 메소드명을 변경하겠습니다.
- MentorCareerDto : MentorCareer Entity를 MentorCareerDto로 변환해주는 from 메소드를 추가하였습니다.
   -  기존 from 메소드가 존재하는데 사용하는 용도가 다른 것 같아, 오버로딩으로 구현하였습니다.
- 예외처리 : NOT_FOUND_MENTOR, HttpStatus.NOT_FOUND
   - DB에 해당 mentorId 가 존재하지 않을 때, 
   - isDeleted가 true인 mentor
   - searchable가 false인 mentor
<br>

## ✨ 이건 꼭 봐주세요! ✨

- http://localhost:8080/v1/api/mentors/detail/7
```json
{
    "success": true,
    "status": 200,
    "message": "Mentor 상세정보를 성공적으로 가져왔습니다.",
    "data": {
        "mentorId": 7,
        "nickname": "JAME",
        "introduction": "Introduction 1",
        "company": "Company 1",
        "thumbnailImageUrl": "https://example.com/thumbnail1.jpg",
        "mentorCareerList": [
            {
                "dutyType": "BACKEND_DEVELOPER",
                "period": "5년 6개월",
                "fullString": "BACKEND_DEVELOPER 5년 6개월"
            },
            {
                "dutyType": "DATA_ENGINEER",
                "period": "2년 3개월",
                "fullString": "DATA_ENGINEER 2년 3개월"
            }
        ]
    }
}
```
