### PR TITLE
멘토 리스트 조회 API : 직무 필터링 기능 추가

### DIFF
--- a/src/main/java/com/github/supercodingfinalprojectbackend/controller/MentorController.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/controller/MentorController.java
@@ -32,12 +32,13 @@ public class MentorController {
 	public ResponseEntity<ApiResponse<Page<MentorInfoResponse>>> getMentors(
 			@RequestParam(required = false, defaultValue = "") String keyword,
 			@RequestParam(required = false) List<String> skillStack,
+			@RequestParam(required = false) List<String> duties,
 			@RequestParam(defaultValue = "0") Long cursor,
 			@RequestParam(defaultValue = "10") Integer pageSize
 	){
 			return ResponseUtils.ok(
 					"Mentor 리스트를 성공적으로 가져왔습니다.",
-					mentorService.getMentors(keyword, skillStack, cursor, PageRequest.of(0, pageSize))
+					mentorService.getMentors(keyword, skillStack, duties, cursor, PageRequest.of(0, pageSize))
 			);
 	}
 

--- a/src/main/java/com/github/supercodingfinalprojectbackend/repository/MentorRepositoryCustom.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/repository/MentorRepositoryCustom.java
@@ -17,5 +17,5 @@ public interface MentorRepositoryCustom {
 			List<String> skillStacks, Pageable pageable);
 
 	Page<MentorInfoResponse> searchAllFromDtoWithCursorPagination(String keyword,
-			List<String> skillStacks, Long cursor, Pageable pageable);
+			List<String> skillStacks, List<String> duties, Long cursor, Pageable pageable);
 }

--- a/src/main/java/com/github/supercodingfinalprojectbackend/repository/MentorRepositoryImpl.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/repository/MentorRepositoryImpl.java
@@ -95,7 +95,7 @@ public class MentorRepositoryImpl implements MentorRepositoryCustom {
 
 	@Override
 	public Page<MentorInfoResponse> searchAllFromDtoWithCursorPagination(String keyword,
-			List<String> skillStacks, Long cursorId, Pageable pageable){
+			List<String> skillStacks, List<String> duties, Long cursorId, Pageable pageable){
 
 		List<MentorInfoResponse> content = jpaQueryFactory
 				.selectDistinct(new QMentorDto_MentorInfoResponse(
@@ -116,7 +116,8 @@ public class MentorRepositoryImpl implements MentorRepositoryCustom {
 						mentor.searchable.eq(true),
 						mentor.isDeleted.eq(false),
 						mentorNameLike(keyword).or(conMentorSkillStack(keyword)),
-						skillStackFiltering(skillStacks)
+						skillStackFiltering(skillStacks),
+						dutyFiltering(duties)
 				)
 				.limit(pageable.getPageSize())
 				.fetch();
@@ -132,7 +133,8 @@ public class MentorRepositoryImpl implements MentorRepositoryCustom {
 						mentor.searchable.eq(true),
 						mentor.isDeleted.eq(false),
 						mentorNameLike(keyword).or(conMentorSkillStack(keyword)),
-						skillStackFiltering(skillStacks)
+						skillStackFiltering(skillStacks),
+						dutyFiltering(duties)
 				);
 
 		return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
@@ -152,5 +154,9 @@ public class MentorRepositoryImpl implements MentorRepositoryCustom {
 
 	private BooleanExpression getRecordsWithCursorId(Long cursorId){
 		return cursorId != null ? mentor.mentorId.gt(cursorId) : null;
+	}
+
+	private BooleanExpression dutyFiltering(List<String> duties){
+		return duties != null ? mentor.currentDuty.in(duties) : null;
 	}
 }

--- a/src/main/java/com/github/supercodingfinalprojectbackend/service/MentorService.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/service/MentorService.java
@@ -38,22 +38,10 @@ public class MentorService {
 	private final MentorCareerRepository mentorCareerRepository;
 
 	public Page<MentorDto.MentorInfoResponse> getMentors(
-			String keyWord, List<String> skillStacks, Long cursor, Pageable pageable){
+			String keyWord, List<String> skillStacks, List<String> duties, Long cursor, Pageable pageable){
 
-//		1차 구현 순수 Entity 조회
-//		List<Mentor> mentors = mentorRepository.searchAll(keyWord, skillStacks);
+		Page<MentorInfoResponse> mentors = mentorRepository.searchAllFromDtoWithCursorPagination(keyWord, skillStacks, duties, cursor, pageable);
 
-//		2차 구현 DTO 조회
-//		List<MentorDto.MentorInfoResponse> mentors = mentorRepository.searchAllFromDto(keyWord, skillStacks);
-
-//		3차 OffsetPagination
-//		Page<MentorInfoResponse> mentors = mentorRepository.searchAllFromDtoWithOffsetPagination(keyWord, skillStacks, pageable);
-
-//		4차 cursorPagination
-		Page<MentorInfoResponse> mentors = mentorRepository.searchAllFromDtoWithCursorPagination(keyWord, skillStacks, cursor, pageable);
-
-//		1차 응답
-//		return mentors.stream().map(MentorDto::fromEntity).collect(Collectors.toList());
 		return mentors;
 	}
 


### PR DESCRIPTION
## 📖 설명 📖

- 직무 필터링 기능 추가
   - 입력 받은 직무 리스트에 해당 되는 직무를 가진 멘토들을 반환합니다.

<br>

## 🔧 추가 및 수정 🔧️

- 매개변수 ```List<String> duties``` 추가 : 필터링 할 직무

