### PR TITLE
UserAbstractAccount.chargePaymoney() 메서드에 Lock을 적용했습니다.

### DIFF
--- a/src/main/java/com/github/supercodingfinalprojectbackend/service/OrderService.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/service/OrderService.java
@@ -61,6 +61,7 @@ public class OrderService {
         OrderSheet orderSheet = orderSheetRepository.findByPostMentorUserUserIdAndOrderSheetIdAndIsDeletedIsFalseAndIsCompletedIsFalse(userId, orderSheetId)
                 .orElseThrow(ApiErrorCode.NOT_FOUND_ORDERSHEET::exception);
 
+
         orderSheet.beRejected();
 
         selectedClassTimeRepository.deleteAllByMentorUserUserIdAndOrderSheet(userId, orderSheet);

--- a/src/test/java/com/github/supercodingfinalprojectbackend/service/TestChargePaymoney.java
+++ b/src/test/java/com/github/supercodingfinalprojectbackend/service/TestChargePaymoney.java
@@ -1,0 +1,40 @@
+package com.github.supercodingfinalprojectbackend.service;
+
+import com.github.supercodingfinalprojectbackend.entity.UserAbstractAccount;
+import org.checkerframework.checker.units.qual.C;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.CountDownLatch;
+
+@SpringBootTest
+public class TestChargePaymoney {
+
+    @Test
+    @Transactional
+    public void testChargePaymoney() throws InterruptedException {
+
+        final int numberOfThread = 1000;
+        UserAbstractAccount account1 = UserAbstractAccount.of();
+        UserAbstractAccount account2 = UserAbstractAccount.of();
+        CountDownLatch latch = new CountDownLatch(numberOfThread);
+
+        for (int i = 0; i < numberOfThread; i++) {
+            new Thread(()->{
+                try {
+                    System.out.println("paymoney1 = " + account1.chargePaymoney(1L));
+//                    System.out.println("paymoney2 = " + account2.chargePaymoneyNoLock(1L));
+                } finally {
+                    latch.countDown();
+                }
+            }).start();
+        }
+        latch.await();
+
+        Assertions.assertEquals(numberOfThread, account1.getPaymoney());
+//        Assertions.assertEquals(numberOfThread, account2.getPaymoney());
+
+    }
+}


### PR DESCRIPTION
## 📖 설명 📖

- UserAbstractAccount.chargePaymoney() 메서드에 Lock을 적용했습니다. 이유는 멘티의 코드리뷰 신청내역이 동시에 여러개 반려되는 경우 어느 하나의 처리가 묻혀서 포인트가 증발하는 버그에 대비하기 위함입니다.
- Lock을 적용하고 정상적으로 동작하는지 테스트하는 테스트코드도 작성해보았습니다.

<br>

## 🔧 추가 및 수정 🔧️

-

<br>

## ✨ 이건 꼭 봐주세요! ✨

-
