### PR TITLE
카카오 첫 로그인인데 중복회원가입이 감지되던 버그 수정

### DIFF
--- a/src/main/java/com/github/supercodingfinalprojectbackend/entity/UserAbstractAccount.java
+++ b/src/main/java/com/github/supercodingfinalprojectbackend/entity/UserAbstractAccount.java
@@ -24,7 +24,7 @@ public class UserAbstractAccount extends CommonEntity {
     @Column(name = "paymoney")
     private Long paymoney;
 
-    private final ReentrantLock chargePaymentLock = new ReentrantLock();
+    private transient final ReentrantLock chargePaymentLock = new ReentrantLock();
 
     private UserAbstractAccount(Long abstractAccountId, String accountNumber, Long paymoney) {
         this.abstractAccountId = abstractAccountId;


### PR DESCRIPTION
## 📖 설명 📖

- 카카오 첫 로그인인데 중복회원이 되던 버그가 수정되었습니다.
- 원인은 엔티티에서 DB에 저장되지 말아야 할 필드가 저장되어서 발생했습니다. 👍 

<br>

## 🔧 추가 및 수정 🔧️

-

<br>

## ✨ 이건 꼭 봐주세요! ✨

-
